### PR TITLE
Add PowerDNS HTTP API client

### DIFF
--- a/pdns/client.go
+++ b/pdns/client.go
@@ -1,0 +1,70 @@
+package pdns
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// Client provides access to the PowerDNS Authoritative HTTP API.
+type Client struct {
+	endpoint *url.URL
+	apiKey   string
+	http     *http.Client
+}
+
+// NewClient creates a new API client. The endpoint should include the
+// base path of the API, for example "http://localhost:8081/api/v1".
+func NewClient(endpoint, apiKey string, httpClient *http.Client) (*Client, error) {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{endpoint: u, apiKey: apiKey, http: httpClient}, nil
+}
+
+func (c *Client) newRequest(ctx context.Context, method, path string, body interface{}) (*http.Request, error) {
+	rel := &url.URL{Path: path}
+	u := c.endpoint.ResolveReference(rel)
+	var buf io.ReadWriter
+	if body != nil {
+		buf = new(bytes.Buffer)
+		if err := json.NewEncoder(buf).Encode(body); err != nil {
+			return nil, err
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), buf)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.apiKey != "" {
+		req.Header.Set("X-API-Key", c.apiKey)
+	}
+	return req, nil
+}
+
+func (c *Client) do(req *http.Request, v interface{}) error {
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%s: %s", resp.Status, string(b))
+	}
+	if v != nil {
+		return json.NewDecoder(resp.Body).Decode(v)
+	}
+	return nil
+}

--- a/pdns/client_test.go
+++ b/pdns/client_test.go
@@ -1,0 +1,71 @@
+package pdns
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListServers(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/servers", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-API-Key") != "secret" {
+			t.Fatalf("missing API key")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		data := []Server{{ID: "localhost"}}
+		json.NewEncoder(w).Encode(data)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c, err := NewClient(srv.URL, "secret", nil)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	ctx := context.Background()
+	servers, err := c.ListServers(ctx)
+	if err != nil {
+		t.Fatalf("ListServers: %v", err)
+	}
+	if len(servers) != 1 || servers[0].ID != "localhost" {
+		t.Fatalf("unexpected servers: %+v", servers)
+	}
+}
+
+func TestCreateZone(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/servers/localhost/zones", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method %s", r.Method)
+		}
+		var z Zone
+		if err := json.NewDecoder(r.Body).Decode(&z); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if z.Name != "example.org." {
+			t.Fatalf("zone name %s", z.Name)
+		}
+		z.ID = z.Name
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(z)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c, err := NewClient(srv.URL, "", nil)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	ctx := context.Background()
+	zone := Zone{Name: "example.org.", Kind: "Master"}
+	res, err := c.CreateZone(ctx, "localhost", zone)
+	if err != nil {
+		t.Fatalf("CreateZone: %v", err)
+	}
+	if res.ID != "example.org." {
+		t.Fatalf("unexpected zone: %+v", res)
+	}
+}

--- a/pdns/doc.go
+++ b/pdns/doc.go
@@ -1,0 +1,2 @@
+// Package pdns provides a client for the PowerDNS Authoritative HTTP API.
+package pdns

--- a/pdns/servers.go
+++ b/pdns/servers.go
@@ -1,0 +1,32 @@
+package pdns
+
+import (
+	"context"
+	"net/http"
+)
+
+// ListServers returns all configured servers.
+func (c *Client) ListServers(ctx context.Context) ([]Server, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, "/servers", nil)
+	if err != nil {
+		return nil, err
+	}
+	var servers []Server
+	if err := c.do(req, &servers); err != nil {
+		return nil, err
+	}
+	return servers, nil
+}
+
+// GetServer returns details about a specific server.
+func (c *Client) GetServer(ctx context.Context, id string) (*Server, error) {
+	req, err := c.newRequest(ctx, http.MethodGet, "/servers/"+id, nil)
+	if err != nil {
+		return nil, err
+	}
+	var server Server
+	if err := c.do(req, &server); err != nil {
+		return nil, err
+	}
+	return &server, nil
+}

--- a/pdns/types.go
+++ b/pdns/types.go
@@ -1,0 +1,35 @@
+package pdns
+
+// Server represents a PowerDNS server instance.
+type Server struct {
+	ID         string `json:"id"`
+	URL        string `json:"url"`
+	DaemonType string `json:"daemon_type,omitempty"`
+	Version    string `json:"version,omitempty"`
+}
+
+// Zone represents a DNS zone managed by PowerDNS.
+type Zone struct {
+	ID      string   `json:"id"`
+	Name    string   `json:"name"`
+	Type    string   `json:"type,omitempty"`
+	Kind    string   `json:"kind"`
+	Serial  int      `json:"serial,omitempty"`
+	Masters []string `json:"masters,omitempty"`
+	RRsets  []RRSet  `json:"rrsets,omitempty"`
+}
+
+// RRSet represents a set of resource records with the same name and type.
+type RRSet struct {
+	Name       string   `json:"name"`
+	Type       string   `json:"type"`
+	TTL        int      `json:"ttl"`
+	Changetype string   `json:"changetype,omitempty"`
+	Records    []Record `json:"records"`
+}
+
+// Record represents a single DNS record within an RRSet.
+type Record struct {
+	Content  string `json:"content"`
+	Disabled bool   `json:"disabled"`
+}

--- a/pdns/zones.go
+++ b/pdns/zones.go
@@ -1,0 +1,70 @@
+package pdns
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// ListZones returns all zones from the given server.
+func (c *Client) ListZones(ctx context.Context, serverID string) ([]Zone, error) {
+	path := fmt.Sprintf("/servers/%s/zones", serverID)
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var zones []Zone
+	if err := c.do(req, &zones); err != nil {
+		return nil, err
+	}
+	return zones, nil
+}
+
+// GetZone retrieves the zone details.
+func (c *Client) GetZone(ctx context.Context, serverID, zoneID string) (*Zone, error) {
+	path := fmt.Sprintf("/servers/%s/zones/%s", serverID, zoneID)
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var z Zone
+	if err := c.do(req, &z); err != nil {
+		return nil, err
+	}
+	return &z, nil
+}
+
+// CreateZone creates a new zone on the specified server.
+func (c *Client) CreateZone(ctx context.Context, serverID string, zone Zone) (*Zone, error) {
+	path := fmt.Sprintf("/servers/%s/zones", serverID)
+	req, err := c.newRequest(ctx, http.MethodPost, path, zone)
+	if err != nil {
+		return nil, err
+	}
+	var created Zone
+	if err := c.do(req, &created); err != nil {
+		return nil, err
+	}
+	return &created, nil
+}
+
+// DeleteZone removes an existing zone from the server.
+func (c *Client) DeleteZone(ctx context.Context, serverID, zoneID string) error {
+	path := fmt.Sprintf("/servers/%s/zones/%s", serverID, zoneID)
+	req, err := c.newRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+	return c.do(req, nil)
+}
+
+// ModifyRRsets applies RRSet changes to the given zone.
+func (c *Client) ModifyRRsets(ctx context.Context, serverID, zoneID string, rrsets []RRSet) error {
+	payload := map[string]interface{}{"rrsets": rrsets}
+	path := fmt.Sprintf("/servers/%s/zones/%s", serverID, zoneID)
+	req, err := c.newRequest(ctx, http.MethodPatch, path, payload)
+	if err != nil {
+		return err
+	}
+	return c.do(req, nil)
+}


### PR DESCRIPTION
## Summary
- add pdns package providing a client for the PowerDNS Authoritative HTTP API
- support listing servers, zone CRUD operations, and RRset modifications
- include basic tests for server listing and zone creation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a9e4cfa40c832ea808114508a8fba6