### PR TITLE
Add auth routes and switch to xid identifiers

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/dlukt/pdns-manager/ent"
 	"github.com/dlukt/pdns-manager/ent/user"
-	"github.com/google/uuid"
+	"github.com/rs/xid"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -34,7 +34,7 @@ func (s *Service) Register(ctx context.Context, in RegisterInput) (*ent.User, st
 	if err != nil {
 		return nil, "", err
 	}
-	token := uuid.New().String()
+	token := xid.New().String()
 	u, err := s.client.User.Create().
 		SetFirstName(in.FirstName).
 		SetLastName(in.LastName).
@@ -76,7 +76,7 @@ func (s *Service) Login(ctx context.Context, email, password string) (*ent.User,
 }
 
 // UpdateProfile updates the user's profile information.
-func (s *Service) UpdateProfile(ctx context.Context, id int, firstName, lastName string) (*ent.User, error) {
+func (s *Service) UpdateProfile(ctx context.Context, id string, firstName, lastName string) (*ent.User, error) {
 	return s.client.User.UpdateOneID(id).
 		SetFirstName(firstName).
 		SetLastName(lastName).
@@ -84,7 +84,7 @@ func (s *Service) UpdateProfile(ctx context.Context, id int, firstName, lastName
 }
 
 // ChangePassword changes a user's password after verifying the old one.
-func (s *Service) ChangePassword(ctx context.Context, id int, oldPassword, newPassword string) error {
+func (s *Service) ChangePassword(ctx context.Context, id string, oldPassword, newPassword string) error {
 	u, err := s.client.User.Get(ctx, id)
 	if err != nil {
 		return err
@@ -100,8 +100,8 @@ func (s *Service) ChangePassword(ctx context.Context, id int, oldPassword, newPa
 }
 
 // ChangeEmail updates the user's email and returns a new verification token.
-func (s *Service) ChangeEmail(ctx context.Context, id int, newEmail string) (string, error) {
-	token := uuid.New().String()
+func (s *Service) ChangeEmail(ctx context.Context, id string, newEmail string) (string, error) {
+	token := xid.New().String()
 	err := s.client.User.UpdateOneID(id).
 		SetEmail(newEmail).
 		SetEmailVerified(false).
@@ -114,7 +114,7 @@ func (s *Service) ChangeEmail(ctx context.Context, id int, newEmail string) (str
 }
 
 // DeleteAccount removes the user from the database.
-func (s *Service) DeleteAccount(ctx context.Context, id int) error {
+func (s *Service) DeleteAccount(ctx context.Context, id string) error {
 	return s.client.User.DeleteOneID(id).Exec(ctx)
 }
 
@@ -124,7 +124,7 @@ func (s *Service) RequestPasswordReset(ctx context.Context, email string) (strin
 	if err != nil {
 		return "", err
 	}
-	token := uuid.New().String()
+	token := xid.New().String()
 	err = s.client.User.UpdateOne(u).SetResetToken(token).Exec(ctx)
 	if err != nil {
 		return "", err

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -7,16 +7,29 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/dlukt/pdns-manager/auth"
+	"github.com/dlukt/pdns-manager/ent"
 	"github.com/dlukt/pdns-manager/web"
+	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/spf13/cobra"
 )
 
 // startCmd represents the start command
+var (
+	dsn string
+)
+
 var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "starts the server",
 	Run: func(cmd *cobra.Command, args []string) {
-		mux := web.NewHandler()
+		client, err := ent.Open("pgx", dsn)
+		if err != nil {
+			fmt.Println("database error:", err)
+			return
+		}
+		defer client.Close()
+		mux := web.NewHandler(auth.NewService(client))
 		fmt.Println("listening on :8080")
 		if err := http.ListenAndServe(":8080", mux); err != nil && err != http.ErrServerClosed {
 			fmt.Println("server error:", err)
@@ -25,5 +38,6 @@ var startCmd = &cobra.Command{
 }
 
 func init() {
+	startCmd.Flags().StringVar(&dsn, "dsn", "postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable", "database DSN")
 	rootCmd.AddCommand(startCmd)
 }

--- a/ent/client.go
+++ b/ent/client.go
@@ -257,7 +257,7 @@ func (c *UserClient) UpdateOne(_m *User) *UserUpdateOne {
 }
 
 // UpdateOneID returns an update builder for the given id.
-func (c *UserClient) UpdateOneID(id int) *UserUpdateOne {
+func (c *UserClient) UpdateOneID(id string) *UserUpdateOne {
 	mutation := newUserMutation(c.config, OpUpdateOne, withUserID(id))
 	return &UserUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
 }
@@ -274,7 +274,7 @@ func (c *UserClient) DeleteOne(_m *User) *UserDeleteOne {
 }
 
 // DeleteOneID returns a builder for deleting the given entity by its id.
-func (c *UserClient) DeleteOneID(id int) *UserDeleteOne {
+func (c *UserClient) DeleteOneID(id string) *UserDeleteOne {
 	builder := c.Delete().Where(user.ID(id))
 	builder.mutation.id = &id
 	builder.mutation.op = OpDeleteOne
@@ -291,12 +291,12 @@ func (c *UserClient) Query() *UserQuery {
 }
 
 // Get returns a User entity by its id.
-func (c *UserClient) Get(ctx context.Context, id int) (*User, error) {
+func (c *UserClient) Get(ctx context.Context, id string) (*User, error) {
 	return c.Query().Where(user.ID(id)).Only(ctx)
 }
 
 // GetX is like Get, but panics if an error occurs.
-func (c *UserClient) GetX(ctx context.Context, id int) *User {
+func (c *UserClient) GetX(ctx context.Context, id string) *User {
 	obj, err := c.Get(ctx, id)
 	if err != nil {
 		panic(err)

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -10,7 +10,7 @@ import (
 var (
 	// UsersColumns holds the columns for the "users" table.
 	UsersColumns = []*schema.Column{
-		{Name: "id", Type: field.TypeInt, Increment: true},
+		{Name: "id", Type: field.TypeString, Unique: true},
 		{Name: "first_name", Type: field.TypeString},
 		{Name: "last_name", Type: field.TypeString},
 		{Name: "email", Type: field.TypeString, Unique: true},

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -31,7 +31,7 @@ type UserMutation struct {
 	config
 	op                 Op
 	typ                string
-	id                 *int
+	id                 *string
 	first_name         *string
 	last_name          *string
 	email              *string
@@ -65,7 +65,7 @@ func newUserMutation(c config, op Op, opts ...userOption) *UserMutation {
 }
 
 // withUserID sets the ID field of the mutation.
-func withUserID(id int) userOption {
+func withUserID(id string) userOption {
 	return func(m *UserMutation) {
 		var (
 			err   error
@@ -115,9 +115,15 @@ func (m UserMutation) Tx() (*Tx, error) {
 	return tx, nil
 }
 
+// SetID sets the value of the id field. Note that this
+// operation is only accepted on creation of User entities.
+func (m *UserMutation) SetID(id string) {
+	m.id = &id
+}
+
 // ID returns the ID value in the mutation. Note that the ID is only available
 // if it was provided to the builder or after it was returned from the database.
-func (m *UserMutation) ID() (id int, exists bool) {
+func (m *UserMutation) ID() (id string, exists bool) {
 	if m.id == nil {
 		return
 	}
@@ -128,12 +134,12 @@ func (m *UserMutation) ID() (id int, exists bool) {
 // That means, if the mutation is applied within a transaction with an isolation level such
 // as sql.LevelSerializable, the returned ids match the ids of the rows that will be updated
 // or updated by the mutation.
-func (m *UserMutation) IDs(ctx context.Context) ([]int, error) {
+func (m *UserMutation) IDs(ctx context.Context) ([]string, error) {
 	switch {
 	case m.op.Is(OpUpdateOne | OpDeleteOne):
 		id, exists := m.ID()
 		if exists {
-			return []int{id}, nil
+			return []string{id}, nil
 		}
 		fallthrough
 	case m.op.Is(OpUpdate | OpDelete):

--- a/ent/runtime.go
+++ b/ent/runtime.go
@@ -14,7 +14,11 @@ func init() {
 	userFields := schema.User{}.Fields()
 	_ = userFields
 	// userDescEmailVerified is the schema descriptor for email_verified field.
-	userDescEmailVerified := userFields[4].Descriptor()
+	userDescEmailVerified := userFields[5].Descriptor()
 	// user.DefaultEmailVerified holds the default value on creation for the email_verified field.
 	user.DefaultEmailVerified = userDescEmailVerified.Default.(bool)
+	// userDescID is the schema descriptor for id field.
+	userDescID := userFields[0].Descriptor()
+	// user.DefaultID holds the default value on creation for the id field.
+	user.DefaultID = userDescID.Default.(func() string)
 }

--- a/ent/schema/user.go
+++ b/ent/schema/user.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/field"
+	"github.com/rs/xid"
 )
 
 // User holds the schema definition for the User entity.
@@ -13,6 +14,10 @@ type User struct {
 // Fields of the User.
 func (User) Fields() []ent.Field {
 	return []ent.Field{
+		field.String("id").
+			DefaultFunc(func() string { return xid.New().String() }).
+			Unique().
+			Immutable(),
 		field.String("first_name"),
 		field.String("last_name"),
 		field.String("email").Unique(),

--- a/ent/user.go
+++ b/ent/user.go
@@ -15,7 +15,7 @@ import (
 type User struct {
 	config `json:"-"`
 	// ID of the ent.
-	ID int `json:"id,omitempty"`
+	ID string `json:"id,omitempty"`
 	// FirstName holds the value of the "first_name" field.
 	FirstName string `json:"first_name,omitempty"`
 	// LastName holds the value of the "last_name" field.
@@ -40,9 +40,7 @@ func (*User) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case user.FieldEmailVerified:
 			values[i] = new(sql.NullBool)
-		case user.FieldID:
-			values[i] = new(sql.NullInt64)
-		case user.FieldFirstName, user.FieldLastName, user.FieldEmail, user.FieldPasswordHash, user.FieldVerificationToken, user.FieldResetToken:
+		case user.FieldID, user.FieldFirstName, user.FieldLastName, user.FieldEmail, user.FieldPasswordHash, user.FieldVerificationToken, user.FieldResetToken:
 			values[i] = new(sql.NullString)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -60,11 +58,11 @@ func (_m *User) assignValues(columns []string, values []any) error {
 	for i := range columns {
 		switch columns[i] {
 		case user.FieldID:
-			value, ok := values[i].(*sql.NullInt64)
-			if !ok {
-				return fmt.Errorf("unexpected type %T for field id", value)
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field id", values[i])
+			} else if value.Valid {
+				_m.ID = value.String
 			}
-			_m.ID = int(value.Int64)
 		case user.FieldFirstName:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field first_name", values[i])

--- a/ent/user/user.go
+++ b/ent/user/user.go
@@ -54,6 +54,8 @@ func ValidColumn(column string) bool {
 var (
 	// DefaultEmailVerified holds the default value on creation for the "email_verified" field.
 	DefaultEmailVerified bool
+	// DefaultID holds the default value on creation for the "id" field.
+	DefaultID func() string
 )
 
 // OrderOption defines the ordering options for the User queries.

--- a/ent/user/where.go
+++ b/ent/user/where.go
@@ -8,48 +8,58 @@ import (
 )
 
 // ID filters vertices based on their ID field.
-func ID(id int) predicate.User {
+func ID(id string) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldID, id))
 }
 
 // IDEQ applies the EQ predicate on the ID field.
-func IDEQ(id int) predicate.User {
+func IDEQ(id string) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldID, id))
 }
 
 // IDNEQ applies the NEQ predicate on the ID field.
-func IDNEQ(id int) predicate.User {
+func IDNEQ(id string) predicate.User {
 	return predicate.User(sql.FieldNEQ(FieldID, id))
 }
 
 // IDIn applies the In predicate on the ID field.
-func IDIn(ids ...int) predicate.User {
+func IDIn(ids ...string) predicate.User {
 	return predicate.User(sql.FieldIn(FieldID, ids...))
 }
 
 // IDNotIn applies the NotIn predicate on the ID field.
-func IDNotIn(ids ...int) predicate.User {
+func IDNotIn(ids ...string) predicate.User {
 	return predicate.User(sql.FieldNotIn(FieldID, ids...))
 }
 
 // IDGT applies the GT predicate on the ID field.
-func IDGT(id int) predicate.User {
+func IDGT(id string) predicate.User {
 	return predicate.User(sql.FieldGT(FieldID, id))
 }
 
 // IDGTE applies the GTE predicate on the ID field.
-func IDGTE(id int) predicate.User {
+func IDGTE(id string) predicate.User {
 	return predicate.User(sql.FieldGTE(FieldID, id))
 }
 
 // IDLT applies the LT predicate on the ID field.
-func IDLT(id int) predicate.User {
+func IDLT(id string) predicate.User {
 	return predicate.User(sql.FieldLT(FieldID, id))
 }
 
 // IDLTE applies the LTE predicate on the ID field.
-func IDLTE(id int) predicate.User {
+func IDLTE(id string) predicate.User {
 	return predicate.User(sql.FieldLTE(FieldID, id))
+}
+
+// IDEqualFold applies the EqualFold predicate on the ID field.
+func IDEqualFold(id string) predicate.User {
+	return predicate.User(sql.FieldEqualFold(FieldID, id))
+}
+
+// IDContainsFold applies the ContainsFold predicate on the ID field.
+func IDContainsFold(id string) predicate.User {
+	return predicate.User(sql.FieldContainsFold(FieldID, id))
 }
 
 // FirstName applies equality check predicate on the "first_name" field. It's identical to FirstNameEQ.

--- a/ent/user_delete.go
+++ b/ent/user_delete.go
@@ -40,7 +40,7 @@ func (_d *UserDelete) ExecX(ctx context.Context) int {
 }
 
 func (_d *UserDelete) sqlExec(ctx context.Context) (int, error) {
-	_spec := sqlgraph.NewDeleteSpec(user.Table, sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt))
+	_spec := sqlgraph.NewDeleteSpec(user.Table, sqlgraph.NewFieldSpec(user.FieldID, field.TypeString))
 	if ps := _d.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {

--- a/ent/user_query.go
+++ b/ent/user_query.go
@@ -82,8 +82,8 @@ func (_q *UserQuery) FirstX(ctx context.Context) *User {
 
 // FirstID returns the first User ID from the query.
 // Returns a *NotFoundError when no User ID was found.
-func (_q *UserQuery) FirstID(ctx context.Context) (id int, err error) {
-	var ids []int
+func (_q *UserQuery) FirstID(ctx context.Context) (id string, err error) {
+	var ids []string
 	if ids, err = _q.Limit(1).IDs(setContextOp(ctx, _q.ctx, ent.OpQueryFirstID)); err != nil {
 		return
 	}
@@ -95,7 +95,7 @@ func (_q *UserQuery) FirstID(ctx context.Context) (id int, err error) {
 }
 
 // FirstIDX is like FirstID, but panics if an error occurs.
-func (_q *UserQuery) FirstIDX(ctx context.Context) int {
+func (_q *UserQuery) FirstIDX(ctx context.Context) string {
 	id, err := _q.FirstID(ctx)
 	if err != nil && !IsNotFound(err) {
 		panic(err)
@@ -133,8 +133,8 @@ func (_q *UserQuery) OnlyX(ctx context.Context) *User {
 // OnlyID is like Only, but returns the only User ID in the query.
 // Returns a *NotSingularError when more than one User ID is found.
 // Returns a *NotFoundError when no entities are found.
-func (_q *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
-	var ids []int
+func (_q *UserQuery) OnlyID(ctx context.Context) (id string, err error) {
+	var ids []string
 	if ids, err = _q.Limit(2).IDs(setContextOp(ctx, _q.ctx, ent.OpQueryOnlyID)); err != nil {
 		return
 	}
@@ -150,7 +150,7 @@ func (_q *UserQuery) OnlyID(ctx context.Context) (id int, err error) {
 }
 
 // OnlyIDX is like OnlyID, but panics if an error occurs.
-func (_q *UserQuery) OnlyIDX(ctx context.Context) int {
+func (_q *UserQuery) OnlyIDX(ctx context.Context) string {
 	id, err := _q.OnlyID(ctx)
 	if err != nil {
 		panic(err)
@@ -178,7 +178,7 @@ func (_q *UserQuery) AllX(ctx context.Context) []*User {
 }
 
 // IDs executes the query and returns a list of User IDs.
-func (_q *UserQuery) IDs(ctx context.Context) (ids []int, err error) {
+func (_q *UserQuery) IDs(ctx context.Context) (ids []string, err error) {
 	if _q.ctx.Unique == nil && _q.path != nil {
 		_q.Unique(true)
 	}
@@ -190,7 +190,7 @@ func (_q *UserQuery) IDs(ctx context.Context) (ids []int, err error) {
 }
 
 // IDsX is like IDs, but panics if an error occurs.
-func (_q *UserQuery) IDsX(ctx context.Context) []int {
+func (_q *UserQuery) IDsX(ctx context.Context) []string {
 	ids, err := _q.IDs(ctx)
 	if err != nil {
 		panic(err)
@@ -365,7 +365,7 @@ func (_q *UserQuery) sqlCount(ctx context.Context) (int, error) {
 }
 
 func (_q *UserQuery) querySpec() *sqlgraph.QuerySpec {
-	_spec := sqlgraph.NewQuerySpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt))
+	_spec := sqlgraph.NewQuerySpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeString))
 	_spec.From = _q.sql
 	if unique := _q.ctx.Unique; unique != nil {
 		_spec.Unique = *unique

--- a/ent/user_update.go
+++ b/ent/user_update.go
@@ -170,7 +170,7 @@ func (_u *UserUpdate) ExecX(ctx context.Context) {
 }
 
 func (_u *UserUpdate) sqlSave(ctx context.Context) (_node int, err error) {
-	_spec := sqlgraph.NewUpdateSpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt))
+	_spec := sqlgraph.NewUpdateSpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeString))
 	if ps := _u.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
@@ -381,7 +381,7 @@ func (_u *UserUpdateOne) ExecX(ctx context.Context) {
 }
 
 func (_u *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) {
-	_spec := sqlgraph.NewUpdateSpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeInt))
+	_spec := sqlgraph.NewUpdateSpec(user.Table, user.Columns, sqlgraph.NewFieldSpec(user.FieldID, field.TypeString))
 	id, ok := _u.mutation.ID()
 	if !ok {
 		return nil, &ValidationError{Name: "id", err: errors.New(`ent: missing "User.id" for update`)}

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.24.6
 require (
 	ariga.io/atlas v0.32.1-0.20250325101103-175b25e1c1b9
 	entgo.io/ent v0.14.5
-	github.com/google/uuid v1.3.0
 	github.com/jackc/pgx/v5 v5.7.5
+	github.com/rs/xid v1.6.0
 	github.com/spf13/cobra v1.9.1
 	golang.org/x/crypto v0.37.0
 )
@@ -17,6 +17,7 @@ require (
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
 	github.com/go-openapi/inflect v0.19.0 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.18.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
+github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=

--- a/web/templates/confirm.html
+++ b/web/templates/confirm.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{.Title}}</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<h1>Email Confirmation</h1>
+<p>{{.Message}}</p>
+</body>
+</html>

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{.Title}}</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<h1>Login</h1>
+{{if .Error}}<p>{{.Error}}</p>{{end}}
+{{if .Message}}<p>{{.Message}}</p>{{end}}
+<form method="post">
+    <input type="email" name="email" placeholder="Email">
+    <input type="password" name="password" placeholder="Password">
+    <button type="submit">Login</button>
+</form>
+</body>
+</html>

--- a/web/templates/register.html
+++ b/web/templates/register.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{.Title}}</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<h1>Register</h1>
+{{if .Error}}<p>{{.Error}}</p>{{end}}
+{{if .Message}}<p>{{.Message}}</p>{{end}}
+<form method="post">
+    <input type="text" name="first_name" placeholder="First Name">
+    <input type="text" name="last_name" placeholder="Last Name">
+    <input type="email" name="email" placeholder="Email">
+    <input type="password" name="password" placeholder="Password">
+    <button type="submit">Register</button>
+</form>
+</body>
+</html>

--- a/web/templates/reset.html
+++ b/web/templates/reset.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{.Title}}</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<h1>Reset Password</h1>
+{{if .Error}}<p>{{.Error}}</p>{{end}}
+{{if .Message}}<p>{{.Message}}</p>{{end}}
+{{if .Token}}
+<form method="post">
+    <input type="hidden" name="token" value="{{.Token}}">
+    <input type="password" name="password" placeholder="New Password">
+    <button type="submit">Reset Password</button>
+</form>
+{{else}}
+<form method="post">
+    <input type="email" name="email" placeholder="Email">
+    <button type="submit">Request Reset</button>
+</form>
+{{end}}
+</body>
+</html>

--- a/web/web.go
+++ b/web/web.go
@@ -5,6 +5,8 @@ import (
 	"html/template"
 	"io/fs"
 	"net/http"
+
+	"github.com/dlukt/pdns-manager/auth"
 )
 
 //go:embed templates/*.html static/*
@@ -23,17 +25,133 @@ func mustStatic() fs.FS {
 	return s
 }
 
+type handler struct {
+	auth *auth.Service
+}
+
 // NewHandler returns an http.Handler with application routes.
-func NewHandler() http.Handler {
+func NewHandler(a *auth.Service) http.Handler {
+	h := &handler{auth: a}
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /", index)
+	mux.HandleFunc("GET /", h.index)
+	mux.HandleFunc("GET /register", h.getRegister)
+	mux.HandleFunc("POST /register", h.postRegister)
+	mux.HandleFunc("GET /login", h.getLogin)
+	mux.HandleFunc("POST /login", h.postLogin)
+	mux.HandleFunc("GET /reset", h.getReset)
+	mux.HandleFunc("POST /reset", h.postReset)
+	mux.HandleFunc("GET /confirm_mail", h.confirmMail)
 	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
 	return mux
 }
 
-func index(w http.ResponseWriter, r *http.Request) {
+func (h *handler) index(w http.ResponseWriter, r *http.Request) {
 	data := struct{ Title string }{Title: "PDNS Manager"}
 	if err := tmpl.ExecuteTemplate(w, "index.html", data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (h *handler) getRegister(w http.ResponseWriter, r *http.Request) {
+	data := struct{ Title, Error, Message string }{Title: "Register"}
+	if err := tmpl.ExecuteTemplate(w, "register.html", data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (h *handler) postRegister(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	in := auth.RegisterInput{
+		FirstName: r.FormValue("first_name"),
+		LastName:  r.FormValue("last_name"),
+		Email:     r.FormValue("email"),
+		Password:  r.FormValue("password"),
+	}
+	_, token, err := h.auth.Register(r.Context(), in)
+	data := struct{ Title, Error, Message string }{Title: "Register"}
+	if err != nil {
+		data.Error = err.Error()
+	} else {
+		data.Message = "Registration successful. Verification token: " + token
+	}
+	if err := tmpl.ExecuteTemplate(w, "register.html", data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (h *handler) getLogin(w http.ResponseWriter, r *http.Request) {
+	data := struct{ Title, Error, Message string }{Title: "Login"}
+	if err := tmpl.ExecuteTemplate(w, "login.html", data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (h *handler) postLogin(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	_, err := h.auth.Login(r.Context(), r.FormValue("email"), r.FormValue("password"))
+	data := struct{ Title, Error, Message string }{Title: "Login"}
+	if err != nil {
+		data.Error = err.Error()
+	} else {
+		data.Message = "Login successful"
+	}
+	if err := tmpl.ExecuteTemplate(w, "login.html", data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (h *handler) getReset(w http.ResponseWriter, r *http.Request) {
+	token := r.URL.Query().Get("token")
+	data := struct{ Title, Token, Error, Message string }{Title: "Reset Password", Token: token}
+	if err := tmpl.ExecuteTemplate(w, "reset.html", data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (h *handler) postReset(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	token := r.FormValue("token")
+	data := struct{ Title, Token, Error, Message string }{Title: "Reset Password"}
+	if token != "" {
+		data.Token = token
+		err := h.auth.ResetPassword(r.Context(), token, r.FormValue("password"))
+		if err != nil {
+			data.Error = err.Error()
+		} else {
+			data.Message = "Password reset successful"
+		}
+	} else {
+		t, err := h.auth.RequestPasswordReset(r.Context(), r.FormValue("email"))
+		if err != nil {
+			data.Error = err.Error()
+		} else {
+			data.Message = "Reset token: " + t
+		}
+	}
+	if err := tmpl.ExecuteTemplate(w, "reset.html", data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (h *handler) confirmMail(w http.ResponseWriter, r *http.Request) {
+	token := r.URL.Query().Get("token")
+	err := h.auth.ConfirmEmail(r.Context(), token)
+	data := struct{ Title, Message string }{Title: "Confirm Email"}
+	if err != nil {
+		data.Message = "Verification failed: " + err.Error()
+	} else {
+		data.Message = "Email confirmed"
+	}
+	if err := tmpl.ExecuteTemplate(w, "confirm.html", data); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }


### PR DESCRIPTION
## Summary
- add register, login, password reset and email confirmation routes with basic HTML forms
- use github.com/rs/xid for user IDs and tokens instead of google/uuid
- initialize auth service and database in start command

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a9fd87a210832e8db68ec2265b18ab