### PR TITLE
Redirect on auth success and add register link

### DIFF
--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -23,6 +23,9 @@
     </form>
     <div class="text-center mt-4">
         <a class="text-blue-500" href="/auth/forgot">Forgot password?</a>
+        <div class="mt-2">
+            <a class="text-blue-500" href="/auth/register">Register</a>
+        </div>
     </div>
 </div>
 <script>


### PR DESCRIPTION
## Summary
- redirect to the home page after successful login or password reset
- add a Register link to the login page for new users

## Testing
- `npm test` *(fails: Missing script "test")*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68aa364428fc832eada5e763606e3d4d