### PR TITLE
Add logout route

### DIFF
--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -21,7 +21,7 @@
                 <div>Admin User</div>
                 <div class="text-sm">
                     <a href="#" class="hover:underline">Edit Profile</a> |
-                    <a href="#" class="hover:underline">Logout</a>
+                    <a href="/auth/logout" class="hover:underline">Logout</a>
                 </div>
             </div>
         </div>

--- a/web/web.go
+++ b/web/web.go
@@ -64,6 +64,7 @@ func NewHandler(a *auth.Service, s *session.Store) http.Handler {
 	mux.HandleFunc("POST /auth/register", h.postRegister)
 	mux.HandleFunc("GET /auth/login", h.getLogin)
 	mux.HandleFunc("POST /auth/login", h.postLogin)
+	mux.HandleFunc("GET /auth/logout", h.getLogout)
 	mux.HandleFunc("GET /auth/reset", h.getReset)
 	mux.HandleFunc("POST /auth/reset", h.postReset)
 	mux.HandleFunc("GET /auth/forgot", h.getForgot)
@@ -160,6 +161,15 @@ func (h *handler) postLogin(w http.ResponseWriter, r *http.Request) {
 	}
 	http.SetCookie(w, &http.Cookie{Name: "session", Value: token, Path: "/", HttpOnly: true})
 	http.Redirect(w, r, "/", http.StatusFound)
+}
+
+func (h *handler) getLogout(w http.ResponseWriter, r *http.Request) {
+	c, err := r.Cookie("session")
+	if err == nil {
+		h.sessions.Delete(c.Value)
+		http.SetCookie(w, &http.Cookie{Name: "session", Value: "", Path: "/", HttpOnly: true, MaxAge: -1})
+	}
+	http.Redirect(w, r, "/auth/login", http.StatusFound)
 }
 
 func (h *handler) getReset(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- implement GET /auth/logout to clear session cookie and delete session
- link layout's Logout action to new route

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68aa3f899994832e8870d94000747c08