### PR TITLE
fix: ensure server settings are saved

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -316,21 +316,19 @@ func (h *handler) postServerSettings(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	if _, err := h.client.Settings.Update().Where(settings.KeyEQ("pdns_api_url")).SetValue(pdnsURL).Save(r.Context()); err != nil {
-		if !ent.IsNotFound(err) {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+	if n, err := h.client.Settings.Update().Where(settings.KeyEQ("pdns_api_url")).SetValue(pdnsURL).Save(r.Context()); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	} else if n == 0 {
 		if _, err := h.client.Settings.Create().SetKey("pdns_api_url").SetValue(pdnsURL).Save(r.Context()); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 	}
-	if _, err := h.client.Settings.Update().Where(settings.KeyEQ("pdns_api_key")).SetValue(pdnsKey).Save(r.Context()); err != nil {
-		if !ent.IsNotFound(err) {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+	if n, err := h.client.Settings.Update().Where(settings.KeyEQ("pdns_api_key")).SetValue(pdnsKey).Save(r.Context()); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	} else if n == 0 {
 		if _, err := h.client.Settings.Create().SetKey("pdns_api_key").SetValue(pdnsKey).Save(r.Context()); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
## Summary
- ensure PDNS API settings rows exist at startup
- handle missing rows when saving server settings

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68aa56fbf1ec832eb1fb4fc301e09fcd