### PR TITLE
fix: dark mode input backgrounds

### DIFF
--- a/web/templates/auth/forgot.html
+++ b/web/templates/auth/forgot.html
@@ -17,7 +17,7 @@
     {{if .Error}}<p class="mb-4 text-red-500">{{.Error}}</p>{{end}}
     {{if .Message}}<p class="mb-4 text-green-500">{{.Message}}</p>{{end}}
     <form method="post" class="space-y-4">
-        <input class="w-full px-3 py-2 border rounded" type="email" name="email" placeholder="Email">
+        <input class="w-full px-3 py-2 border rounded bg-white dark:bg-gray-700" type="email" name="email" placeholder="Email">
         <button class="w-full bg-blue-500 text-white py-2 rounded" type="submit">Request Reset</button>
     </form>
 </div>

--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -17,8 +17,8 @@
     {{if .Error}}<p class="mb-4 text-red-500">{{.Error}}</p>{{end}}
     {{if .Message}}<p class="mb-4 text-green-500">{{.Message}}</p>{{end}}
     <form method="post" class="space-y-4">
-        <input class="w-full px-3 py-2 border rounded" type="email" name="email" placeholder="Email">
-        <input class="w-full px-3 py-2 border rounded" type="password" name="password" placeholder="Password">
+        <input class="w-full px-3 py-2 border rounded bg-white dark:bg-gray-700" type="email" name="email" placeholder="Email">
+        <input class="w-full px-3 py-2 border rounded bg-white dark:bg-gray-700" type="password" name="password" placeholder="Password">
         <button class="w-full bg-blue-500 text-white py-2 rounded" type="submit">Login</button>
     </form>
     <div class="text-center mt-4">

--- a/web/templates/auth/register.html
+++ b/web/templates/auth/register.html
@@ -17,10 +17,10 @@
     {{if .Error}}<p class="mb-4 text-red-500">{{.Error}}</p>{{end}}
     {{if .Message}}<p class="mb-4 text-green-500">{{.Message}}</p>{{end}}
     <form method="post" class="space-y-4">
-        <input class="w-full px-3 py-2 border rounded" type="text" name="first_name" placeholder="First Name">
-        <input class="w-full px-3 py-2 border rounded" type="text" name="last_name" placeholder="Last Name">
-        <input class="w-full px-3 py-2 border rounded" type="email" name="email" placeholder="Email">
-        <input class="w-full px-3 py-2 border rounded" type="password" name="password" placeholder="Password">
+        <input class="w-full px-3 py-2 border rounded bg-white dark:bg-gray-700" type="text" name="first_name" placeholder="First Name">
+        <input class="w-full px-3 py-2 border rounded bg-white dark:bg-gray-700" type="text" name="last_name" placeholder="Last Name">
+        <input class="w-full px-3 py-2 border rounded bg-white dark:bg-gray-700" type="email" name="email" placeholder="Email">
+        <input class="w-full px-3 py-2 border rounded bg-white dark:bg-gray-700" type="password" name="password" placeholder="Password">
         <button class="w-full bg-blue-500 text-white py-2 rounded" type="submit">Register</button>
     </form>
 </div>

--- a/web/templates/auth/reset.html
+++ b/web/templates/auth/reset.html
@@ -17,8 +17,8 @@
     {{if .Error}}<p class="mb-4 text-red-500">{{.Error}}</p>{{end}}
     {{if .Message}}<p class="mb-4 text-green-500">{{.Message}}</p>{{end}}
     <form method="post" class="space-y-4">
-        <input class="w-full px-3 py-2 border rounded" type="text" name="token" placeholder="Reset Token" value="{{.Token}}">
-        <input class="w-full px-3 py-2 border rounded" type="password" name="password" placeholder="New Password">
+        <input class="w-full px-3 py-2 border rounded bg-white dark:bg-gray-700" type="text" name="token" placeholder="Reset Token" value="{{.Token}}">
+        <input class="w-full px-3 py-2 border rounded bg-white dark:bg-gray-700" type="password" name="password" placeholder="New Password">
         <button class="w-full bg-blue-500 text-white py-2 rounded" type="submit">Reset Password</button>
     </form>
 </div>

--- a/web/templates/settings/server.html
+++ b/web/templates/settings/server.html
@@ -8,11 +8,11 @@
 <form method="POST" action="/settings/server" class="space-y-4 max-w-md">
     <div>
         <label class="block mb-1" for="pdns_api_url">PowerDNS API URL</label>
-        <input id="pdns_api_url" name="pdns_api_url" type="text" value="{{.PDNSAPIURL}}" class="w-full p-2 border rounded" required>
+        <input id="pdns_api_url" name="pdns_api_url" type="text" value="{{.PDNSAPIURL}}" class="w-full p-2 border rounded bg-white dark:bg-gray-700" required>
     </div>
     <div>
         <label class="block mb-1" for="pdns_api_key">PowerDNS API Key</label>
-        <input id="pdns_api_key" name="pdns_api_key" type="text" value="{{.PDNSAPIKey}}" class="w-full p-2 border rounded" required>
+        <input id="pdns_api_key" name="pdns_api_key" type="text" value="{{.PDNSAPIKey}}" class="w-full p-2 border rounded bg-white dark:bg-gray-700" required>
     </div>
     <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Save</button>
 </form>


### PR DESCRIPTION
## Summary
- ensure auth and settings form inputs adopt dark backgrounds in dark theme

## Testing
- `npm run build:css`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68aa59c3edbc832e80b708924ccafc14